### PR TITLE
Ajustes posts table

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "postinstall": "prisma generate --schema=src/database/prisma/schema.prisma"
   },
+  "prisma": {
+    "schema": "src/database/prisma/schema.prisma"
+  },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.0.0",

--- a/src/database/prisma/migrations/20230916202306_add_post_slug_column/migration.sql
+++ b/src/database/prisma/migrations/20230916202306_add_post_slug_column/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[slug]` on the table `Post` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `slug` to the `Post` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "slug" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Post_slug_key" ON "Post"("slug" DESC);

--- a/src/database/prisma/migrations/20230916202510_add_post_cover_url_column/migration.sql
+++ b/src/database/prisma/migrations/20230916202510_add_post_cover_url_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "coverUrl" TEXT;

--- a/src/database/prisma/schema.prisma
+++ b/src/database/prisma/schema.prisma
@@ -10,8 +10,10 @@ datasource db {
 model Post {
   id          String    @id @default(uuid())
   title       String
+  slug        String    @unique(sort: Desc)
+  coverUrl    String?
   description String
-  status  Int
+  status      Int
   createdbyid String
   updatedbyid String?
   createdby   User      @relation("postcreated", fields: [createdbyid], references: [id])

--- a/src/domain/entities/post.entity.ts
+++ b/src/domain/entities/post.entity.ts
@@ -5,6 +5,8 @@ import { UserEntity } from './user.entity';
 export class PostEntity extends EntityBase {
   title: string;
   description: string;
+  slug: string;
+  coverUrl?: string;
   status: PostStatusEnum;
   createdbyid: string;
   updatedbyid?: string;

--- a/src/modules/post/application/appService/post.service.ts
+++ b/src/modules/post/application/appService/post.service.ts
@@ -41,7 +41,7 @@ export class PostService {
     }
 
     const userEntity: UserEntity = await this.userRepository.getUser(
-      post.UpdatedById,
+      post.updatedById,
     );
     if (!userEntity) {
       throw new Error('User not found.');
@@ -54,7 +54,7 @@ export class PostService {
   }
 
   public async createPost(post: PostCreateUpdateDTO): Promise<void> {
-    if (!post.CreatedById) {
+    if (!post.createdById) {
       throw new Error(
         'Its mandatory the post to contain a user who is creating.',
       );

--- a/src/modules/post/application/dtos/post.create.update.dto.ts
+++ b/src/modules/post/application/dtos/post.create.update.dto.ts
@@ -2,28 +2,34 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class PostCreateUpdateDTO {
   @ApiProperty()
-  Title: string;
+  title: string;
 
   @ApiProperty()
-  Description: string;
+  description: string;
 
   @ApiProperty()
-  PostStatus: number;
+  slug: string;
 
   @ApiProperty()
-  CreatedById: string;
+  coverUrl: string;
+
+  @ApiProperty()
+  status: number;
+
+  @ApiProperty()
+  createdById: string;
 
   @ApiProperty({
     nullable: true,
   })
-  UpdatedById?: string;
+  updatedById?: string;
 
   @ApiProperty()
-  CreatedAt: Date;
+  createdAt: Date;
 
   @ApiProperty({
     nullable: true,
   })
   @ApiProperty()
-  UpdatedAt?: Date;
+  updatedAt?: Date;
 }

--- a/src/modules/post/application/dtos/post.read.dto.ts
+++ b/src/modules/post/application/dtos/post.read.dto.ts
@@ -3,26 +3,26 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class PostReadDTO {
   @ApiProperty()
-  Id: string;
+  id: string;
 
   @ApiProperty()
-  Title: string;
+  title: string;
 
   @ApiProperty()
-  Description: string;
+  description: string;
 
   @ApiProperty()
-  PostStatus: number;
+  status: number;
 
   @ApiProperty()
-  CreatedBy: UserReadDto;
+  createdBy: UserReadDto;
 
   @ApiProperty()
-  UpdatedBy?: UserReadDto;
+  updatedBy?: UserReadDto;
 
   @ApiProperty()
-  CreatedAt: Date;
+  createdAt: Date;
 
   @ApiProperty()
-  UpdatedAt?: Date;
+  updatedAt?: Date;
 }

--- a/src/modules/post/common/util/post-converter.ts
+++ b/src/modules/post/common/util/post-converter.ts
@@ -4,14 +4,14 @@ import { PostEntity } from '../../../../domain/entities/post.entity';
 
 export function modelToDTO(entity: PostEntity): PostReadDTO {
   return {
-    Id: entity.id,
-    Title: entity.title,
-    Description: entity.description,
-    PostStatus: entity.status,
-    CreatedBy: entity.createdby,
-    UpdatedBy: entity.updatedby,
-    CreatedAt: entity.createdat,
-    UpdatedAt: entity.updatedat,
+    id: entity.id,
+    title: entity.title,
+    description: entity.description,
+    status: entity.status,
+    createdBy: entity.createdby,
+    updatedBy: entity.updatedby,
+    createdAt: entity.createdat,
+    updatedAt: entity.updatedat,
   };
 }
 
@@ -25,11 +25,13 @@ export function modelToDtoList(entityList: PostEntity[]): PostReadDTO[] {
 export function dtoToModel(dto: PostCreateUpdateDTO): PostEntity {
   return {
     createdby: undefined,
-    createdbyid: dto.CreatedById,
-    title: dto.Title,
-    description: dto.Description,
-    status: dto.PostStatus,
-    createdat: dto.CreatedAt,
-    updatedat: dto.UpdatedAt,
+    createdbyid: dto.createdById,
+    title: dto.title,
+    description: dto.description,
+    slug: dto.slug,
+    coverUrl: dto.coverUrl,
+    status: dto.status,
+    createdat: dto.createdAt,
+    updatedat: dto.updatedAt,
   };
 }

--- a/src/modules/post/infra/repositories/post.repository.impl.ts
+++ b/src/modules/post/infra/repositories/post.repository.impl.ts
@@ -12,6 +12,8 @@ export class PostRepository implements PostRepositoryInterface {
       data: {
         title: postEntity.title,
         description: postEntity.description,
+        slug: postEntity.slug,
+        coverUrl: postEntity.coverUrl,
         status: postEntity.status,
         createdbyid: postEntity.createdbyid,
         updatedbyid: postEntity.updatedbyid,


### PR DESCRIPTION
- Adiciona colunas Slug e Cover Url.
- Configa o caminho padrão do schema.prisma no package.json (torna desnecessário passar a flag --schema toda vez que for rodar `npx prisma migrate`.
- Ajusta campos dos dtos para camel case.